### PR TITLE
webhookd: load .env and ignore self actors

### DIFF
--- a/services/webhookd/deno.json
+++ b/services/webhookd/deno.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "exports": "./mod.ts",
   "tasks": {
-    "dev": "deno run -A --watch mod.ts",
-    "start": "deno run -A mod.ts",
+    "dev": "deno run -A --env-file=.env --watch mod.ts",
+    "start": "deno run -A --env-file=.env mod.ts",
     "fmt": "deno fmt",
     "check": "deno check mod.ts"
   },

--- a/services/webhookd/src/handlers/github.ts
+++ b/services/webhookd/src/handlers/github.ts
@@ -239,9 +239,15 @@ function shouldIgnoreWebhook(
     return 'self_comment_signature';
   }
 
+  const ignore = getIgnoreActors();
+
+  // Extra guard: ignore when extracted context shows an ignored actor (covers cases where
+  // payload.sender differs from the content author, or sender is missing).
+  if (ctx.commentAuthor && ignore.has(ctx.commentAuthor)) return `comment_author_ignored:${ctx.commentAuthor}`;
+  if (ctx.author && ignore.has(ctx.author)) return `author_ignored:${ctx.author}`;
+
   if (isRecord(payload)) {
     const sender = payload.sender as GithubActor | undefined;
-    const ignore = getIgnoreActors();
     if (sender?.login && ignore.has(sender.login)) return `sender_ignored:${sender.login}`;
   }
 


### PR DESCRIPTION
Fix webhookd startup to load .env via deno task, and strengthen ignore logic to skip events authored by ignored actors (sender/commentAuthor/author).