### PR TITLE
rote-notes: fix OpenKey auth helper + add security note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This repo is intended to be:
 
 ## Conventions
 
+### Security note (important)
+
+OpenClaw and webhook receivers like `webhookd` can reduce risk with signatures, allowlists, dedupe, and loop-prevention — but **nothing is perfectly secure**.
+
+- Assume there is always some risk of prompt-injection, misconfiguration, or remote abuse.
+- Keep secrets out of repos.
+- Prefer running OpenClaw + local services **inside Docker** (or another sandbox) with minimal privileges.
+- Do not expose internal ports directly to the public Internet; use a tunnel/reverse proxy and keep auth enabled.
+
+
 ### Secrets & local-only files
 
 - **Never commit** `.env`, private keys, certificates, or machine-specific files.

--- a/skills/rote-notes/SKILL.md
+++ b/skills/rote-notes/SKILL.md
@@ -44,7 +44,11 @@ If you need a deterministic call from the host machine, use:
 
 - Treat API Keys as passwords.
 - Do not store API Keys in notes, repositories, or logs.
-- Prefer header auth: `Authorization: Bearer <API_KEY>`.
+- Prefer **least-privilege** OpenKeys.
+- Auth mechanism varies by deployment:
+  - Some deployments accept `Authorization: Bearer <API_KEY>`.
+  - Others require `openkey=<API_KEY>` (query) or `{"openkey": "..."}` (JSON body).
+  - This skill defaults to the latter when using the helper script.
 
 ## Reference
 


### PR DESCRIPTION
- Fix rote_openkey.py to send OpenKey as  (query for GET, JSON field for POST) to match deployments that do not accept Authorization header.\n- Update rote-notes SKILL.md security notes to mention auth variants.\n- Add a brief security warning to repo README recommending running OpenClaw services in Docker / sandbox.