### PR TITLE
rote-notes: support creating articles via OpenKey

### DIFF
--- a/skills/rote-notes/SKILL.md
+++ b/skills/rote-notes/SKILL.md
@@ -27,6 +27,11 @@ Use this skill to treat **Rote** as the user’s default note backend: capture n
   - tags include `inbox` (or a user-chosen default tag)
   - title optional
 
+### 1b) Create an article (OpenKey)
+
+- Use `POST /openkey/articles` with JSON body `{ content }`.
+- Requires OpenKey permission: `SENDARTICLE`.
+
 If you need a deterministic call from the host machine, use:
 - `scripts/rote_openkey.ts` (Deno, recommended)
 - `scripts/rote_openkey.py` (Python, kept as a fallback)

--- a/skills/rote-notes/scripts/rote_openkey.ts
+++ b/skills/rote-notes/scripts/rote_openkey.ts
@@ -97,7 +97,9 @@ function takeRepeatable(args: string[], name: string): string[] {
 async function main(argv: string[]): Promise<number> {
   const [cmd, ...args] = argv;
   if (!cmd || cmd === '-h' || cmd === '--help') {
-    console.log(`Rote OpenKey client\n\nCommands:\n  create --content <text> [--title <t>] [--tag <t> ...] [--pin] [--private|--public] [--type rote|article|other]\n  list [--skip N] [--limit N] [--archived true|false] [--tag <t> ...]\n  search --keyword <kw> [--skip N] [--limit N] [--archived true|false] [--tag <t> ...]\n`);
+    console.log(
+      `Rote OpenKey client\n\nCommands:\n  create --content <text> [--title <t>] [--tag <t> ...] [--pin] [--private|--public] [--type rote|other]\n  create-article --content <text>\n  list [--skip N] [--limit N] [--archived true|false] [--tag <t> ...]\n  search --keyword <kw> [--skip N] [--limit N] [--archived true|false] [--tag <t> ...]\n`,
+    );
     return 0;
   }
 
@@ -121,6 +123,17 @@ async function main(argv: string[]): Promise<number> {
         pin,
         state,
       },
+    });
+    console.log(JSON.stringify(data, null, 2));
+    return 0;
+  }
+
+  if (cmd === 'create-article') {
+    const content = takeArg(args, '--content');
+    if (!content) throw new Error('Missing --content');
+
+    const data = await request('POST', '/openkey/articles', {
+      body: { content },
     });
     console.log(JSON.stringify(data, null, 2));
     return 0;


### PR DESCRIPTION
- Extend Deno helper  with  (POST /openkey/articles).\n- Update skill docs to mention OpenKey article creation and required permission .\n\nTested against https://api.rote.ink/v2/api with an OpenKey that has SENDARTICLE.